### PR TITLE
Upload build artifact to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,3 +19,10 @@ jobs:
     - name: Build
       run: npx --package mini-cross mc --no-tty _ make
 
+    - name: Upload executable artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: minecraft-mod-log-player-health
+        path: build/libs/*.jar
+        if-no-files-found: error
+


### PR DESCRIPTION
Make it easier for casual users to use the mod without having to build it themselves.